### PR TITLE
🧪 [testing improvement] Add test for entity deletion error path in reset settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ credentials
 maps
 logs
 temp
+coverage

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.js', '**/*.spec.js'],
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "start": "ts-node .",
         "preinstall": "npx npm-force-resolutions",
-        "test": "tsc --noEmit -p ."
+        "test": "tsc --noEmit -p . && jest"
     },
     "repository": {
         "type": "git",
@@ -44,6 +44,8 @@
         "protobufjs": "7.2.4"
     },
     "devDependencies": {
+        "@types/jest": "^30.0.0",
+        "jest": "^30.4.2",
         "typescript": "^5.9.3"
     }
 }

--- a/src/commands/__tests__/reset.test.js
+++ b/src/commands/__tests__/reset.test.js
@@ -1,0 +1,111 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+// Mock external dependencies
+jest.mock('../../handlers/permissionHandler.js', () => ({
+  getPermissionsRemoved: jest.fn().mockReturnValue('mock-perms'),
+  resetPermissionsAllChannels: jest.fn().mockResolvedValue(true)
+}));
+
+jest.mock('../../discordTools/discordTools.js', () => ({
+  getGuild: jest.fn().mockReturnValue({ id: 'guild-123' }),
+  getCategoryById: jest.fn(),
+  clearTextChannel: jest.fn().mockResolvedValue(true)
+}));
+
+jest.mock('../../discordTools/SetupSettingsMenu', () => jest.fn().mockResolvedValue(true));
+
+// Mock Config and DiscordEmbeds correctly
+jest.mock('../../structures/Config', () => ({
+  discord: {
+    needAdminPrivileges: true
+  }
+}), { virtual: true });
+
+jest.mock('../../structures/DiscordEmbeds', () => ({
+  getActionInfoEmbed: jest.fn().mockReturnValue('embed-data')
+}), { virtual: true });
+
+const PermissionHandler = require('../../handlers/permissionHandler.js');
+const DiscordTools = require('../../discordTools/discordTools.js');
+const SetupSettingsMenu = require('../../discordTools/SetupSettingsMenu');
+
+const resetCommand = require('../reset');
+
+describe('reset command', () => {
+  let client;
+  let interaction;
+
+  beforeEach(() => {
+    client = {
+      validatePermissions: jest.fn().mockResolvedValue(true),
+      isAdministrator: jest.fn().mockReturnValue(true),
+      intlGet: jest.fn().mockReturnValue('mock-string'),
+      log: jest.fn(),
+      interactionEditReply: jest.fn().mockResolvedValue(true),
+      getInstance: jest.fn().mockReturnValue({
+        channelId: {
+          category: 'category-123'
+        }
+      }),
+      logInteraction: jest.fn()
+    };
+
+    interaction = {
+      guildId: 'guild-123',
+      deferReply: jest.fn().mockResolvedValue(true),
+      options: {
+        getSubcommand: jest.fn()
+      }
+    };
+
+    jest.clearAllMocks();
+  });
+
+  describe('settings subcommand', () => {
+    it('should handle entity deletion error path (ignore error)', async () => {
+      interaction.options.getSubcommand.mockReturnValue('settings');
+
+      const mockCategory = {
+        permissionOverwrites: {
+          set: jest.fn().mockRejectedValue(new Error('Entity deletion error'))
+        }
+      };
+      DiscordTools.getCategoryById.mockResolvedValue(mockCategory);
+
+      // Execute the command handler
+      await resetCommand.execute(client, interaction);
+
+      // Verification steps
+      expect(DiscordTools.getCategoryById).toHaveBeenCalledWith('guild-123', 'category-123');
+      expect(mockCategory.permissionOverwrites.set).toHaveBeenCalledWith('mock-perms');
+
+      // The function should not throw, meaning it ignored the error and continued execution
+      expect(SetupSettingsMenu).toHaveBeenCalledWith(client, { id: 'guild-123' }, true);
+      expect(PermissionHandler.resetPermissionsAllChannels).toHaveBeenCalledWith(client, { id: 'guild-123' });
+      expect(client.interactionEditReply).toHaveBeenCalled();
+    });
+
+    it('should successfully set permissions when no error occurs', async () => {
+      interaction.options.getSubcommand.mockReturnValue('settings');
+
+      const mockCategory = {
+        permissionOverwrites: {
+          set: jest.fn().mockResolvedValue(true)
+        }
+      };
+      DiscordTools.getCategoryById.mockResolvedValue(mockCategory);
+
+      // Execute the command handler
+      await resetCommand.execute(client, interaction);
+
+      // Verification steps
+      expect(DiscordTools.getCategoryById).toHaveBeenCalledWith('guild-123', 'category-123');
+      expect(mockCategory.permissionOverwrites.set).toHaveBeenCalledWith('mock-perms');
+
+      // Continued execution
+      expect(SetupSettingsMenu).toHaveBeenCalledWith(client, { id: 'guild-123' }, true);
+      expect(PermissionHandler.resetPermissionsAllChannels).toHaveBeenCalledWith(client, { id: 'guild-123' });
+      expect(client.interactionEditReply).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** This PR adds a missing test for the entity deletion error path in the `settings` subcommand of the `reset` command.
📊 **Coverage:** The tests now correctly mock out external dependencies and explicitly test both the happy path and the case where an error is thrown during setting permission overwrites.
✨ **Result:** Increased test coverage and validation that the application ignores entity deletion errors correctly as it should when attempting to delete overwrites. I also added `jest` to the testing tools to be executed on `npm test`.

---
*PR created automatically by Jules for task [6407537867157239428](https://jules.google.com/task/6407537867157239428) started by @Zuescho*