### PR TITLE
🧹 Remove unused Decay import in RustPlus.js

### DIFF
--- a/src/structures/RustPlus.js
+++ b/src/structures/RustPlus.js
@@ -25,7 +25,6 @@ const Translate = require('translate');
 
 const Client = require('../../index.ts');
 const Constants = require('../util/constants.js');
-const Decay = require('../util/decay.js');
 const DiscordEmbeds = require('../discordTools/discordEmbeds');
 const DiscordMessages = require('../discordTools/discordMessages.js');
 const DiscordTools = require('../discordTools/discordTools.js');


### PR DESCRIPTION
🎯 **What:** Removed unused `Decay` import from `src/structures/RustPlus.js`.
💡 **Why:** The import was unused, so removing it improves code health and maintainability by cleaning up dead code.
✅ **Verification:** Verified via `grep` that `Decay` is no longer in the file and isn't used anywhere else in that file. Passed code review.
✨ **Result:** A cleaner file without unnecessary dependencies.

---
*PR created automatically by Jules for task [14637487154420095061](https://jules.google.com/task/14637487154420095061) started by @Zuescho*