### PR TITLE
fix: resolve bug-review findings (embed cap, clanTag, snapshot dedup, cargo dup)

### DIFF
--- a/src/discordTools/discordEmbeds.js
+++ b/src/discordTools/discordEmbeds.js
@@ -1175,10 +1175,12 @@ module.exports = {
                 block += '\n';
             }
 
-            /* Stop adding players once we're near Discord's 6000-char total
-               limit — the alternative (silently dropping fields) would be
-               worse for the reader than a clear cutoff. */
-            if (totalCharacters + block.length > Constants.EMBED_MAX_TOTAL_CHARACTERS - 200) break;
+            /* Stop adding players once the description nears Discord's 4096-char
+               per-description limit — every block is concatenated into a single
+               embed description, so the binding cap is the description limit, not
+               the 6000-char embed total. Silently dropping is worse than a clear
+               cutoff. */
+            if (totalCharacters + block.length > Constants.EMBED_MAX_DESCRIPTION_CHARACTERS - 200) break;
             totalCharacters += block.length;
             description += block;
         }

--- a/src/handlers/battlemetricsHandler.js
+++ b/src/handlers/battlemetricsHandler.js
@@ -60,6 +60,12 @@ module.exports = {
         const searchSteamProfiles = (client.battlemetricsIntervalCounter === 0) ? true : false;
         const calledSteamProfiles = new Object();
 
+        /* Dedupe activity-log snapshots within one poll cycle: a player tracked
+           on two active trackers (or across guilds) would otherwise insert two
+           rows with the same checked_at, inflating sample counts and risking
+           conflicting online states. Snapshot each BM player at most once. */
+        const snapshottedThisCycle = new Set();
+
         if (!firstTime) await client.updateBattlemetricsInstances();
 
         for (const guildItem of client.guilds.cache) {
@@ -105,7 +111,11 @@ module.exports = {
                 let onlineSet = null;
                 if (trackedIds.length > 0) {
                     onlineSet = new Set(bmInstance.onlinePlayers.map(String));
-                    ActivityDb.logSnapshot(trackedIds, onlineSet, Math.floor(Date.now() / 1000));
+                    const newIds = trackedIds.filter(id => !snapshottedThisCycle.has(id));
+                    if (newIds.length > 0) {
+                        ActivityDb.logSnapshot(newIds, onlineSet, Math.floor(Date.now() / 1000));
+                        for (const id of newIds) snapshottedThisCycle.add(id);
+                    }
                     onlineNowCount = trackedIds.filter(id => onlineSet.has(String(id))).length;
                 }
 

--- a/src/handlers/modalHandler.js
+++ b/src/handlers/modalHandler.js
@@ -440,6 +440,15 @@ module.exports = async (client, interaction) => {
             }
         }
 
+        /* Mirror the slash-command/scraper convention: prefix the tracker's
+           clanTag onto real names so modal-added players match the rest of the
+           roster and don't trip a spurious name-change alert on the next Steam
+           re-scrape. Placeholders ('-'/null) stay untagged so the heal path can
+           resolve and tag them later. */
+        if (tracker.clanTag && name && name !== '-') {
+            name = `${tracker.clanTag} ${name}`;
+        }
+
         tracker.players.push({
             name: name,
             steamId: steamId,

--- a/src/structures/MapMarkers.js
+++ b/src/structures/MapMarkers.js
@@ -1145,6 +1145,13 @@ class MapMarkers {
            fallback doesn't re-fire next poll. */
         if (!firstTimer) {
             const cargoShipMeta = this.cargoShipMetaData[id];
+            /* The direction-based fallback in updateCargoShips may already have
+               announced this ship leaving (isLeaving set). Don't emit a second
+               identical 'cargoShipLeaving' notification. */
+            if (cargoShipMeta && cargoShipMeta.isLeaving) {
+                cargoShip.onItsWayOut = true;
+                return;
+            }
             if (cargoShipMeta) cargoShipMeta.isLeaving = true;
             cargoShip.onItsWayOut = true;
         }


### PR DESCRIPTION
Fixes the four bugs surfaced by a two-agent code review of the fork.

## Findings addressed

### HIGH — Activity Report breaks for large trackers
`src/discordTools/discordEmbeds.js` — `getTrackerActivityReportEmbed` accumulated every player block into a single embed **description** but guarded against the 6000-char *embed total*. Discord caps a description at **4096**, so a tracker with ~13+ players produced a 4097-5800-char description that threw `RangeError` in `EmbedBuilder.setDescription`; `buttonHandler` swallowed it and users only saw "Failed to generate the activity report." Now gated on `EMBED_MAX_DESCRIPTION_CHARACTERS - 200`.

### MEDIUM — Modal "Add Player" dropped the tracker clanTag
`src/handlers/modalHandler.js` — the slash-command and periodic-scraper paths prefix `tracker.clanTag`; the modal path didn't. With a clanTag set, steam/vanity adds tripped a spurious `trackerNewNameDetected` alert on the next scrape and BM-id adds stayed permanently untagged. Now prefixes real names; placeholders (`-`/null) stay untagged so the heal path tags them later.

### LOW-MEDIUM — Duplicate activity-log snapshots
`src/handlers/battlemetricsHandler.js` — `logSnapshot` ran once per tracker, so a player on two active trackers inserted two rows with the same `checked_at`, inflating `getSampleCount` (trips the 500-sample raid-alert threshold ~2x too fast) and risking conflicting `is_online` values across different BM servers. Now deduped to one snapshot per BM player per poll cycle.

### LOW — Duplicate cargo "leaving" notification
`src/structures/MapMarkers.js` — `notifyCargoShipEgressAfterHarbor` (after-harbor timer) re-emitted `cargoShipLeaving` without checking `isLeaving`, so it could double-fire after the direction-based fallback already announced it. Now bails early when `isLeaving` is set.

## Verification
- `npx tsc --noEmit -p .` — clean
- `node --test` (utils suite) — pass
- `node --check` on all four edited files — pass